### PR TITLE
feat(cache): implement indexedDB caching for API responses

### DIFF
--- a/src/hooks/optionGroup/useGetOptionGroups.ts
+++ b/src/hooks/optionGroup/useGetOptionGroups.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useDataQuery } from "@dhis2/app-runtime";
 import useShowAlerts from "../commons/useShowAlert";
 import { OptionGroupsConfig, OptionGroupsConfigState } from "../../schema/optionGroupsSchema";
+import { useCacheData } from "../useCacheData/useCacheData";
 
 const OPTION_GROUPS_QUERY = {
     results: {
@@ -23,6 +24,7 @@ type OptionGroupsQueryResponse = {
 
 export function useGetOptionGroups():any {
     const { hide, show } = useShowAlerts()
+    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
     const [error, setError] = useState<boolean>(false)
     const [, setOptionGroupsConfigState] = useRecoilState(OptionGroupsConfigState);
 
@@ -37,12 +39,22 @@ export function useGetOptionGroups():any {
         },
         onComplete(response: { results: { optionGroups: any[] } }) {
             setOptionGroupsConfigState(response?.results?.optionGroups);
+            // Salva no cache com uma chave fixa para o conjunto
+            saveDataToDB({ id: 'optionGroups', data: response?.results?.optionGroups }, 'optionGroups');
         },
         lazy: true
     })
 
     useEffect(() => {
-        void refetch()
+
+        (async () => {
+            const cached = await getDataFromDB('optionGroups', 'optionGroups');
+            if (cached?.data && Array.isArray(cached.data) && cached.data.length > 0) {
+                setOptionGroupsConfigState(cached.data);
+            } else {
+                void refetch();
+            }
+        })();
     }, [])
 
     return { loadingOptionGroups, refetch, errorOptionGroups: error }

--- a/src/hooks/orgUnitsGroup/useOrgUnitsGroups.ts
+++ b/src/hooks/orgUnitsGroup/useOrgUnitsGroups.ts
@@ -26,7 +26,7 @@ export function useOrgUnitsGroups():any {
     const { hide, show } = useShowAlerts()
     const [error, setError] = useState<boolean>(false)
     const [, setOrgUnitsGroupsConfigState] = useRecoilState(OrgUnitsGroupsConfigState);
-    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
+    const { getDataFromDB, saveDataToDB } = useCacheData();
 
     const { data, loading: loadingOrgUnitsGroups, refetch } = useDataQuery<OrgUnitGroupsQueryResponse>(OPTION_GROUPS_QUERY, {
         onError(error: { message: string }) {
@@ -45,7 +45,6 @@ export function useOrgUnitsGroups():any {
     })
 
     useEffect(() => {
-        initializeDB();
 
         (async () => {
             const cached = await getDataFromDB('organisationUnitGroups', 'organisationUnitGroups');

--- a/src/hooks/orgUnitsGroup/useOrgUnitsGroups.ts
+++ b/src/hooks/orgUnitsGroup/useOrgUnitsGroups.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useDataQuery } from "@dhis2/app-runtime";
 import useShowAlerts from "../commons/useShowAlert";
 import { OrgUnitsGroupsConfig, OrgUnitsGroupsConfigState } from "../../schema/orgUnitsGroupSchema";
+import { useCacheData } from "../useCacheData/useCacheData";
 
 const OPTION_GROUPS_QUERY = {
     results: {
@@ -25,6 +26,7 @@ export function useOrgUnitsGroups():any {
     const { hide, show } = useShowAlerts()
     const [error, setError] = useState<boolean>(false)
     const [, setOrgUnitsGroupsConfigState] = useRecoilState(OrgUnitsGroupsConfigState);
+    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
 
     const { data, loading: loadingOrgUnitsGroups, refetch } = useDataQuery<OrgUnitGroupsQueryResponse>(OPTION_GROUPS_QUERY, {
         onError(error: { message: string }) {
@@ -37,12 +39,22 @@ export function useOrgUnitsGroups():any {
         },
         onComplete(response: { results: { organisationUnitGroups: any[] } }) {
             setOrgUnitsGroupsConfigState(response?.results?.organisationUnitGroups);
+            saveDataToDB({ id: 'organisationUnitGroups', data: response?.results?.organisationUnitGroups }, 'organisationUnitGroups');
         },
         lazy: true
     })
 
     useEffect(() => {
-        void refetch()
+        initializeDB();
+
+        (async () => {
+            const cached = await getDataFromDB('organisationUnitGroups', 'organisationUnitGroups');
+            if (cached?.data && Array.isArray(cached.data) && cached.data.length > 0) {
+                setOrgUnitsGroupsConfigState(cached.data);
+            } else {
+                void refetch()
+            }
+        })();
     }, [])
 
     return { loadingOrgUnitsGroups, refetch, errorOrgUnitsGroups: error }

--- a/src/hooks/programRules/hooks/useGetProgramRules.ts
+++ b/src/hooks/programRules/hooks/useGetProgramRules.ts
@@ -4,6 +4,7 @@ import { useDataQuery } from "@dhis2/app-runtime";
 import useShowAlerts from "../../commons/useShowAlert";
 import { ProgramRulesConfigState } from "../../../schema/programRulesSchema";
 import { ProgramRuleConfig } from "../../../types/programRules/ProgramRulesTypes";
+import { useCacheData } from "../../../hooks/useCacheData/useCacheData";
 
 const PROGRAM_RULES_QUERY = {
     results: {
@@ -25,6 +26,7 @@ type ProgramRulesQueryResponse = {
 
 export function useGetProgramRules(programs: string[]):any {
     const { hide, show } = useShowAlerts()
+    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
     const [error, setError] = useState<boolean>(false)
     const [, setProgramRulesConfigState] = useRecoilState(ProgramRulesConfigState);
 
@@ -42,12 +44,22 @@ export function useGetProgramRules(programs: string[]):any {
         },
         onComplete(response: { results: { programRules: any[] } }) {
             setProgramRulesConfigState(response?.results?.programRules);
+            saveDataToDB({ id: 'programRules', data: response?.results?.programRules }, 'programRules');
         },
         lazy: true
     })
 
     useEffect(() => {
-        void refetch()
+        initializeDB();
+
+        (async () => {
+            const cached = await getDataFromDB('programRules', 'programRules');
+            if (cached?.data && Array.isArray(cached.data) && cached.data.length > 0) {
+                setProgramRulesConfigState(cached.data);
+            } else {
+                void refetch();
+            }
+        })();
     }, [])
 
     return { loadingPRules, refetch, errorPRules: error }

--- a/src/hooks/programRules/hooks/useGetProgramRules.ts
+++ b/src/hooks/programRules/hooks/useGetProgramRules.ts
@@ -26,7 +26,7 @@ type ProgramRulesQueryResponse = {
 
 export function useGetProgramRules(programs: string[]):any {
     const { hide, show } = useShowAlerts()
-    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
+    const { getDataFromDB, saveDataToDB } = useCacheData();
     const [error, setError] = useState<boolean>(false)
     const [, setProgramRulesConfigState] = useRecoilState(ProgramRulesConfigState);
 
@@ -50,8 +50,6 @@ export function useGetProgramRules(programs: string[]):any {
     })
 
     useEffect(() => {
-        initializeDB();
-
         (async () => {
             const cached = await getDataFromDB('programRules', 'programRules');
             if (cached?.data && Array.isArray(cached.data) && cached.data.length > 0) {

--- a/src/hooks/programRules/hooks/useGetProgramRulesVariables.ts
+++ b/src/hooks/programRules/hooks/useGetProgramRulesVariables.ts
@@ -4,6 +4,7 @@ import { useDataQuery } from "@dhis2/app-runtime";
 import useShowAlerts from "../../commons/useShowAlert";
 import { ProgramRulesVariablesConfigState } from "../../../schema/programRulesVariablesSchema";
 import { ProgramRuleVariableConfig } from "../../../types/programRules/ProgramRulesTypes";
+import { useCacheData } from "../../../hooks/useCacheData/useCacheData";
 
 const PROGRAM_RULES_VARIABLES_QUERY = {
     results: {
@@ -25,6 +26,7 @@ type ProgramRulesVariablesQueryResponse = {
 
 export function useGetProgramRulesVariables(programs: string[]):any {
     const { hide, show } = useShowAlerts()
+    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
     const [error, setError] = useState<boolean>(false)
     const [, setProgramRuleVariablesConfigState] = useRecoilState(ProgramRulesVariablesConfigState);
 
@@ -42,12 +44,22 @@ export function useGetProgramRulesVariables(programs: string[]):any {
         },
         onComplete(response: { results: { programRuleVariables: any[] } }) {
             setProgramRuleVariablesConfigState(response?.results?.programRuleVariables);
+            saveDataToDB({ id: 'programRuleVariables', data: response?.results?.programRuleVariables }, 'programRuleVariables');
         },
         lazy: true
     })
 
     useEffect(() => {
-        void refetch()
+        initializeDB();
+
+        (async () => {
+            const cached = await getDataFromDB('programRuleVariables', 'programRuleVariables');
+            if (cached?.data && Array.isArray(cached.data) && cached.data.length > 0) {
+                setProgramRuleVariablesConfigState(cached.data);
+            } else {
+                void refetch();
+            }
+        })();
     }, [])
 
     return { loadingPRulesVariables, refetch, errorPRulesVariables: error }

--- a/src/hooks/programRules/hooks/useGetProgramRulesVariables.ts
+++ b/src/hooks/programRules/hooks/useGetProgramRulesVariables.ts
@@ -26,7 +26,7 @@ type ProgramRulesVariablesQueryResponse = {
 
 export function useGetProgramRulesVariables(programs: string[]):any {
     const { hide, show } = useShowAlerts()
-    const { initializeDB, getDataFromDB, saveDataToDB } = useCacheData();
+    const { getDataFromDB, saveDataToDB } = useCacheData();
     const [error, setError] = useState<boolean>(false)
     const [, setProgramRuleVariablesConfigState] = useRecoilState(ProgramRulesVariablesConfigState);
 
@@ -50,8 +50,6 @@ export function useGetProgramRulesVariables(programs: string[]):any {
     })
 
     useEffect(() => {
-        initializeDB();
-
         (async () => {
             const cached = await getDataFromDB('programRuleVariables', 'programRuleVariables');
             if (cached?.data && Array.isArray(cached.data) && cached.data.length > 0) {

--- a/src/hooks/useCacheData/useCacheData.ts
+++ b/src/hooks/useCacheData/useCacheData.ts
@@ -1,0 +1,116 @@
+interface TableName {
+    tableName: "programs" | "optionGroups" | "programRules" | "programRuleVariables" | "organisationUnitGroups"
+}
+
+export const useCacheData = () => {
+
+    const initializeDB = () => {
+        const idb = window.indexedDB || (window as any).mozIndexedBD ||
+            (window as any).webkitIndexedDB || (window as any).msIndexedBD ||
+            (window as any).shimIndexedDB;
+
+        const dbPromise = idb.open("semis-db", 2);
+
+        dbPromise.onupgradeneeded = (event: any) => {
+            var db = event.target.result;
+            if (!db.objectStoreNames.contains('programs')) {
+                db.createObjectStore('programs', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('optionGroups')) {
+                db.createObjectStore('optionGroups', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('programRules')) {
+                db.createObjectStore('programRules', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('programRuleVariables')) {
+                db.createObjectStore('programRuleVariables', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('organisationUnitGroups')) {
+                db.createObjectStore('organisationUnitGroups', { keyPath: "id" })
+            }
+        }
+
+
+        dbPromise.onsuccess = (event: any) => {
+            var db = event.target.result;
+            if (!db.objectStoreNames.contains('programs')) {
+                db.createObjectStore('programs', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('optionGroups')) {
+                db.createObjectStore('optionGroups', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('programRules')) {
+                db.createObjectStore('programRules', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('programRuleVariables')) {
+                db.createObjectStore('programRuleVariables', { keyPath: "id" })
+            }
+
+            if (!db.objectStoreNames.contains('organisationUnitGroups')) {
+                db.createObjectStore('organisationUnitGroups', { keyPath: "id" })
+            }
+        }
+    }
+
+    const saveDataToDB = (data: any, tableName: TableName["tableName"] ) => {
+        const idb = window.indexedDB || (window as any).mozIndexedBD ||
+            (window as any).webkitIndexedDB || (window as any).msIndexedBD ||
+            (window as any).shimIndexedDB;
+
+        const dbPromise = idb.open("semis-db", 2);
+        dbPromise.onsuccess = () => {
+            const db = dbPromise.result;
+            const tx = db.transaction(tableName, "readwrite");
+            const options = tx.objectStore(tableName);
+
+            const option = options.put(data)
+
+            option.onsuccess = () => {
+                tx.oncomplete = () => {
+                    db.close()
+                }
+            }
+        }
+    }
+
+    const getDataFromDB = (tableName: TableName["tableName"], id: string): Promise<any | null> => {
+        return new Promise((resolve) => {
+            const idb = window.indexedDB || (window as any).mozIndexedBD ||
+                (window as any).webkitIndexedDB || (window as any).msIndexedBD ||
+                (window as any).shimIndexedDB;
+
+            const dbPromise = idb.open("semis-db", 2);
+            dbPromise.onsuccess = () => {
+                const db = dbPromise.result;
+                const tx = db.transaction(tableName, "readonly");
+                const store = tx.objectStore(tableName);
+                const request = store.get(id);
+
+                request.onsuccess = () => {
+                    resolve(request.result ?? null);
+                };
+                request.onerror = () => {
+                    resolve(null);
+                };
+                tx.oncomplete = () => {
+                    db.close();
+                };
+            };
+            dbPromise.onerror = () => resolve(null);
+        });
+    }
+
+    return {
+        initializeDB,
+        saveDataToDB,
+        getDataFromDB
+    }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { UserInfoState } from "./schema/userInfoSchema"
 import { useGetSysInfo } from "./hooks/system/info"
 import { getSysInfo } from "./hooks/system/getSysInfo"
 import { useIncrementDays } from "./utils/attendance/getDates"
+import { useCacheData } from "./hooks/useCacheData/useCacheData"
 
 export {
     useBuildForm,
@@ -77,5 +78,6 @@ export {
     UserInfoState,
     useGetSysInfo,
     getSysInfo,
-    useIncrementDays
+    useIncrementDays,
+    useCacheData
 }


### PR DESCRIPTION
Add useCacheData hook to manage indexedDB operations for caching API responses Modify useGetOptionGroups, useGetProgramRules, useOrgUnitsGroups, and useGetProgramRulesVariables hooks to use cached data when available Initialize indexedDB with required object stores and provide methods for saving and retrieving data