### PR TITLE
feat(tei): add support for ORG_UNIT_CODE in pattern generation

### DIFF
--- a/src/hooks/orgUnit/useGetOrgUnitDetails.ts
+++ b/src/hooks/orgUnit/useGetOrgUnitDetails.ts
@@ -1,0 +1,24 @@
+import { useDataEngine } from "@dhis2/app-runtime"
+import { useState } from "react"
+
+export const useGetOrgUnitDetails = () => {
+    const engine = useDataEngine()
+    const [loading, setLoading] = useState<boolean>(false)
+
+    const getOrgUnitDetails = async ({ orgUnit, params }:
+        { orgUnit: string, params: Record<string, string> }): Promise<any> => {
+        setLoading(true)
+        const res = await engine.query({
+            results: {
+                resource: `organisationUnits/${orgUnit}`,
+                params: {
+                    ...params
+                }
+            }
+        })
+        setLoading(false)
+        return res
+    }
+
+    return { getOrgUnitDetails, loading }
+}

--- a/src/hooks/tei/useGetPatternCode.tsx
+++ b/src/hooks/tei/useGetPatternCode.tsx
@@ -17,6 +17,7 @@ const TEI_ATTRIBUTES: any = {
 
 export const useGetPatternCode = () => {
     const engine = useDataEngine()
+    const [error, setError] = useState(false)
     const [loadingCodes, setloadingCodes] = useState(false)
     const [value, setvalue] = useState<GeneratedCodeType>({})
     const { getPatternCodeParams } = useGetPatternCodeParams()
@@ -29,7 +30,7 @@ export const useGetPatternCode = () => {
             let code: PatternCodeQueryResults = { results: { value: "" } }
 
             if (pattern?.length) {
-                const params = await getPatternCodeParams({ pattern, orgUnit, params: {} })
+                const params = await getPatternCodeParams({ pattern, orgUnit, params: {}, onFail: () => setError(true) })
                 code = await engine.query(TEI_ATTRIBUTES, { variables: { id, params } }) as unknown as PatternCodeQueryResults
                 patterns.push({ [id]: code?.results?.value })
             }
@@ -41,6 +42,7 @@ export const useGetPatternCode = () => {
     }
 
     return {
+        errorLoading: error,
         returnPattern,
         loadingCodes,
         generatedVariables: value

--- a/src/hooks/tei/useGetPatternCode.tsx
+++ b/src/hooks/tei/useGetPatternCode.tsx
@@ -1,15 +1,17 @@
 import { useState } from "react";
 import { useDataEngine } from "@dhis2/app-runtime"
 import { CustomAttributeProps } from "dhis2-semis-types";
+import { useGetPatternCodeParams } from "./useGetPatternCodeParams";
 import { GeneratedCodeType, PatternCodeQueryResults } from "../../types/api/GeneratedCodeTypes";
 
 const TEI_ATTRIBUTES: any = {
     results: {
         resource: "trackedEntityAttributes",
         id: ({ id }: { id: string }) => `${id}/generate`,
-        params: {
+        params: ({ params }: { params: object }) => ({
+            ...params,
             expiration: 3
-        }
+        })
     }
 }
 
@@ -17,16 +19,18 @@ export const useGetPatternCode = () => {
     const engine = useDataEngine()
     const [loadingCodes, setloadingCodes] = useState(false)
     const [value, setvalue] = useState<GeneratedCodeType>({})
+    const { getPatternCodeParams } = useGetPatternCodeParams()
 
-    async function returnPattern(variables: CustomAttributeProps[]) {
+    async function returnPattern(variables: CustomAttributeProps[], orgUnit: string) {
         setloadingCodes(true)
         const patterns = []
         for (const variable of variables) {
             const { pattern = "", name: id }: CustomAttributeProps = variable
             let code: PatternCodeQueryResults = { results: { value: "" } }
-            
+
             if (pattern?.length) {
-                code = await engine.query(TEI_ATTRIBUTES, { variables: { id } }) as unknown as PatternCodeQueryResults
+                const params = await getPatternCodeParams({ pattern, orgUnit, params: {} })
+                code = await engine.query(TEI_ATTRIBUTES, { variables: { id, params } }) as unknown as PatternCodeQueryResults
                 patterns.push({ [id]: code?.results?.value })
             }
         }

--- a/src/hooks/tei/useGetPatternCodeParams.ts
+++ b/src/hooks/tei/useGetPatternCodeParams.ts
@@ -1,0 +1,20 @@
+import { useGetOrgUnitDetails } from "../orgUnit/useGetOrgUnitDetails"
+
+export const useGetPatternCodeParams = () => {
+    const { getOrgUnitDetails } = useGetOrgUnitDetails()
+
+    const getPatternCodeParams = async ({ pattern, orgUnit, params }:
+        { pattern: string, orgUnit: string, params: Record<string, string> }) => {
+        if (pattern.includes("ORG_UNIT_CODE")) {
+            const orgUnitCode = await getOrgUnitDetails({ orgUnit, params: { fields: "code" } })
+
+            if (orgUnitCode?.results?.code) {
+                params = { ORG_UNIT_CODE: orgUnitCode?.results?.code }
+            }
+        }
+
+        return params
+    }
+
+    return { getPatternCodeParams }
+}

--- a/src/hooks/tei/useGetPatternCodeParams.ts
+++ b/src/hooks/tei/useGetPatternCodeParams.ts
@@ -1,15 +1,22 @@
+import { useShowAlerts } from "../.."
 import { useGetOrgUnitDetails } from "../orgUnit/useGetOrgUnitDetails"
 
 export const useGetPatternCodeParams = () => {
+    const { show } = useShowAlerts()
     const { getOrgUnitDetails } = useGetOrgUnitDetails()
 
-    const getPatternCodeParams = async ({ pattern, orgUnit, params }:
-        { pattern: string, orgUnit: string, params: Record<string, string> }) => {
+    const getPatternCodeParams = async ({ pattern, orgUnit, params, onFail }:
+        { pattern: string, orgUnit: string, params: Record<string, string>, onFail: () => void }) => {
         if (pattern.includes("ORG_UNIT_CODE")) {
             const orgUnitCode = await getOrgUnitDetails({ orgUnit, params: { fields: "code" } })
 
             if (orgUnitCode?.results?.code) {
                 params = { ORG_UNIT_CODE: orgUnitCode?.results?.code }
+            }
+
+            else {
+                show({ type: { critical: true }, message: "Error on attributes auto-generator: School code not found." })
+                onFail()
             }
         }
 


### PR DESCRIPTION
Implement useGetPatternCodeParams hook to fetch organization unit code when pattern contains ORG_UNIT_CODE placeholder. This enables dynamic code generation based on organizational context.