### PR TITLE
feat: export useGetPatternCodeParams hook for TEI pattern code handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { useGetSysInfo } from "./hooks/system/info"
 import { getSysInfo } from "./hooks/system/getSysInfo"
 import { useIncrementDays } from "./utils/attendance/getDates"
 import { useCacheData } from "./hooks/useCacheData/useCacheData"
+import { useGetPatternCodeParams } from "./hooks/tei/useGetPatternCodeParams"
 
 export {
     useBuildForm,
@@ -79,5 +80,6 @@ export {
     useGetSysInfo,
     getSysInfo,
     useIncrementDays,
-    useCacheData
+    useCacheData,
+    useGetPatternCodeParams
 }


### PR DESCRIPTION
Add the useGetPatternCodeParams hook to the main exports to make it available for external use. This enables components to access TEI pattern code parameters throughout the application.