### PR TITLE
refactor(hooks): migrate enrollment and TEI deletion to tracker API

### DIFF
--- a/src/hooks/enrollment/useDeleteEnrollment.ts
+++ b/src/hooks/enrollment/useDeleteEnrollment.ts
@@ -1,35 +1,69 @@
-import { useDataEngine } from "@dhis2/app-runtime";
-import { useState } from "react";
+import { useState, useCallback } from "react";
+import { useDataEngine, } from "@dhis2/app-runtime";
 
-const ENROLLMENT_MUTATION: any = {
-    resource: "enrollments",
-    type: 'delete',
-    id: ({ id }: any) => id,
-}
+const DELETE_ENROLLMENT_MUTATION = {
+    resource: "tracker",
+    type: 'create',
+    data: ({ data }: { data: any }) => data,
+    params: {
+        async: false,
+        importStrategy: "DELETE",
+    },
+} as any;
 
-export function useDeleteEnrollment(): any {
+const ENROLLMENT_QUERY = {
+    results: {
+        resource: "tracker/enrollments",
+        id: ({ id }: { id: string }) => id,
+        params: {
+            fields: "enrollment,trackedEntity,program,status,orgUnit,enrolledAt,occurredAt,followUp,deleted,createdBy,updatedBy",
+        },
+    },
+} as any;
+
+type DeleteEnrollmentCallbacks = {
+    onComplete?: () => void;
+    onError?: (error: unknown) => void;
+};
+
+const returnEnrollmentBody = (enrollment: any) => ({
+    enrollments: [{
+        ...enrollment,
+        deleted: true,
+    }]
+});
+
+export function useDeleteEnrollment() {
     const engine = useDataEngine();
-    const [loading, setLoading] = useState<boolean>(false)
-    const [error, setError] = useState<unknown>(null)
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<unknown>(null);
 
+    const deleteEnrollment = useCallback(
+        async (enrollmentId: string, { onComplete, onError }: DeleteEnrollmentCallbacks = {}) => {
+            setLoading(true);
+            setError(null);
 
-    async function deleteEnrollment(enrollment: string, onComplete?: () => void, onError?: (error?: unknown) => void) {
-        try {
-            setLoading(true)
-            const response = await engine.mutate(ENROLLMENT_MUTATION, { variables: { id: enrollment } });
-            if (onComplete) {
-                onComplete()
+            try {
+                const { results } = (await engine.query(ENROLLMENT_QUERY, {
+                    variables: { id: enrollmentId },
+                }));
+
+                if (!results) throw new Error("Enrollment not found");
+
+                await engine.mutate(DELETE_ENROLLMENT_MUTATION, {
+                    variables: { data: returnEnrollmentBody(results) },
+                });
+
+                onComplete?.();
+            } catch (err) {
+                setError(err);
+                onError?.(err);
+            } finally {
+                setLoading(false);
             }
-            return response;
-        } catch (error) {
-            setError(error)
-            if (onError) {
-                onError(error)
-            }
-        } finally {
-            setLoading(false)
-        }
-    }
+        },
+        [engine]
+    );
 
-    return { deleteEnrollment, loading, error }
+    return { deleteEnrollment, loading, error };
 }

--- a/src/hooks/image/useFileResource.ts
+++ b/src/hooks/image/useFileResource.ts
@@ -68,7 +68,11 @@ export const useFileResource = () => {
             try {
                 file = await engine.query(GETFILERESOURCEQUERY({ trackedEntity, attribute }))
             } catch (error) {
-                file = await engine.query(GETFILERESOURCEQUERYUP40({ trackedEntity, attribute, program }))
+                try {
+                    file = await engine.query(GETFILERESOURCEQUERYUP40({ trackedEntity, attribute, program }))
+                } catch (error) {
+                    setloading(false)
+                }
             }
             setloading(false)
 

--- a/src/hooks/programRules/rules-engine/RulesEngine.ts
+++ b/src/hooks/programRules/rules-engine/RulesEngine.ts
@@ -197,7 +197,7 @@ export const CustomDhis2RulesEngine = (props: RulesEngineProps) => {
 
                 case "SHOWERROR":
                     variable.error = !!conditionResult;
-                    variable.required = !!conditionResult;
+                    // variable.required = !!conditionResult;
                     variable.content = conditionResult ? rule.content : "";
                     break;
 

--- a/src/hooks/tei/useDeleteTei.ts
+++ b/src/hooks/tei/useDeleteTei.ts
@@ -1,34 +1,91 @@
+import { useCallback, useState } from "react";
 import { useDataEngine } from "@dhis2/app-runtime";
-import { useState } from "react";
 
-const DELETE_TEI_MUTATION: any = {
-    resource: 'trackedEntityInstances',
-    type: 'delete',
-    id: ({ id }: any) => id,
-}
 
-export function useDeleteTEI():any {
-    const [loading, setLoading] = useState<boolean>(false)
-    const [error, setError] = useState<unknown>(null)
+const DELETE_TRACKER_MUTATION = {
+    resource: "tracker",
+    type: 'create',
+    data: ({ data }: { data: any }) => data,
+    params: {
+        async: false,
+        importStrategy: "DELETE",
+    },
+}  as any;
+
+const TRACKER_QUERY = {
+    results: {
+        resource: "tracker/trackedEntities",
+        id: ({ id }: { id: string }) => id,
+        params: {
+            fields: "*",
+        },
+    },
+} as any;
+
+type DeleteTrackerCallbacks = {
+    onComplete?: () => void;
+    onError?: (error: unknown) => void;
+};
+
+const returnTrackerBody = (trackedEntity: any) => ({
+    trackedEntities: [{
+        ...trackedEntity,
+        deleted: true,
+    }]
+});
+
+
+export function useDeleteTEI(): any {
     const engine = useDataEngine();
+    const [error, setError] = useState<unknown>(null)
+    const [loading, setLoading] = useState<boolean>(false)
 
-    async function deleteTEI(trackedEntity: string, onComplete?: () => void, onError?: (error?: unknown) => void) {
-        try {
-            setLoading(true)
-            const response = await engine.mutate(DELETE_TEI_MUTATION, { variables: { id: trackedEntity } });
-            if (onComplete) {
-                onComplete()
+    const deleteTEI = useCallback(
+        async (enrollmentId: string, { onComplete, onError }: DeleteTrackerCallbacks = {}) => {
+            setLoading(true);
+            setError(null);
+
+            try {
+                const { results } = (await engine.query(TRACKER_QUERY, {
+                    variables: { id: enrollmentId },
+                }));
+
+                if (!results) throw new Error("Tracked Entity not found");
+
+                console.log(results)
+
+                await engine.mutate(DELETE_TRACKER_MUTATION, {
+                    variables: { data: returnTrackerBody(results) },
+                });
+
+                onComplete?.();
+            } catch (err) {
+                setError(err);
+                onError?.(err);
+            } finally {
+                setLoading(false);
             }
-            return response;
-        } catch (error) {
-            setError(error)
-            if (onError) {
-                onError(error)
-            }
-        } finally {
-            setLoading(false)
-        }
-    }
+        },
+        [engine]
+    );
+
+    // async function deleteTEI(trackedEntity: string, onComplete?: () => void, onError?: (error?: unknown) => void) {
+    //     try {
+    //         setLoading(true)
+    //         const response = await engine.mutate(DELETE_TEI_MUTATION, { variables: { id: trackedEntity } });
+    //         if (onComplete) {
+    //             onComplete()
+    //         }
+    //         return response;
+    //     } catch (error) {
+    //         setError(error)
+    //         if (onError) {
+    //             onError(error)
+    //         }
+    //     } finally {
+    //         setLoading(false)
+    //     }
+    // }
 
     return { deleteTEI, loading, error }
 }

--- a/src/types/api/WithRegistrationTypes.ts
+++ b/src/types/api/WithRegistrationTypes.ts
@@ -2,7 +2,7 @@ interface TeiQueryProps {
     program: string
     pageSize?: number
     ouMode?: string
-    trackedEntity: string[]
+    trackedEntities: string[]
     orgUnit?: string
     order?: string
     paging?: boolean


### PR DESCRIPTION
Replace direct DELETE mutations with tracker import strategy for enrollment and tracked entity deletion.

- Update useDeleteEnrollment to query enrollment data and send DELETE import
- Update useDeleteTEI similarly with tracked entity data