### PR TITLE
feat(tracker-migration):

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { useCacheData } from "./hooks/useCacheData/useCacheData"
 import { useGetPatternCodeParams } from "./hooks/tei/useGetPatternCodeParams"
 import { useGetCompleteEvents } from "./hooks/events/useGetCompleteEvents"
 import { useGetCompleteTeis } from "./hooks/tei/useGetCompleteTei"
+import { getOwnershipTransferQueryPropsCandidates } from "./utils/tracker-migration/ownershipTransferParamsMapping"
 
 
 
@@ -88,4 +89,5 @@ export {
     useGetPatternCodeParams,
     useGetCompleteEvents,
     useGetCompleteTeis,
+    getOwnershipTransferQueryPropsCandidates,
 }

--- a/src/utils/tracker-migration/ownershipTransferParamsMapping.ts
+++ b/src/utils/tracker-migration/ownershipTransferParamsMapping.ts
@@ -1,0 +1,89 @@
+import { transformQueryParams } from "./tranformParams"
+
+type OwnershipTransferQueryProps = {
+    program: string
+    ou: string
+    trackedEntityInstance: string
+}
+
+type MapRule = {
+    to: string
+    transform?: (value: any) => any
+}
+
+const commonRules: Record<string, MapRule> = {
+    trackedEntityInstance: {
+        to: "trackedEntity"
+    }
+}
+
+const modernRules: Record<string, MapRule> = {
+    ...commonRules
+}
+
+const legacyRules: Record<string, MapRule> = {
+    ...commonRules,
+    ou: {
+        to: "orgUnit"
+    }
+}
+
+function normalizeApiVersion(apiVersion: unknown): number | undefined {
+    const version = Number(apiVersion)
+    return Number.isFinite(version) ? version : undefined
+}
+
+function stringifyParams(params: Record<string, any>) {
+    return JSON.stringify(
+        Object.keys(params)
+            .sort()
+            .reduce((acc, key) => {
+                acc[key] = params[key]
+                return acc
+            }, {} as Record<string, any>)
+    )
+}
+
+function convertOwnershipTransferQueryProps({
+    queryProps,
+    apiVersion
+}: {
+    queryProps: OwnershipTransferQueryProps,
+    apiVersion?: number | string
+}) {
+    const version = normalizeApiVersion(apiVersion)
+    const useLegacyOrder = version !== undefined && version < 41
+    const rules = useLegacyOrder ? legacyRules : modernRules
+
+    return transformQueryParams({ rules, params: queryProps })
+}
+
+function getOwnershipTransferQueryPropsCandidates({
+    queryProps,
+    apiVersion
+}: {
+    queryProps: OwnershipTransferQueryProps,
+    apiVersion?: number | string
+}) {
+    const preferred = convertOwnershipTransferQueryProps({ queryProps, apiVersion })
+    const alternate = transformQueryParams({
+        rules: preferred.orgUnit ? modernRules : legacyRules,
+        params: queryProps
+    })
+
+    const seen = new Set<string>()
+
+    return [preferred, alternate].filter((candidate) => {
+        const key = stringifyParams(candidate)
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+    })
+}
+
+export {
+    convertOwnershipTransferQueryProps,
+    getOwnershipTransferQueryPropsCandidates
+}
+
+export type { OwnershipTransferQueryProps }


### PR DESCRIPTION
- add ownership transfer params mapping for DHIS2 version compatibility
-  Add a shared tracker-migration helper to build ownership transfer query params for tracker/ownership/transfer across DHIS2 versions that expect either 'ou' or 'orgUnit'.
-  Reuse the existing tracker-migration transform utility pattern and expose candidate param mappings so feature modules can try a version-preferred shape and fall back safely. 
- Export getOwnershipTransferQueryPropsCandidates from dhis2-semis-functions for use by transfer approval flows and other modules that need ownership transfer compatibility.
- Tested on DHIS2 versions 2.39 and 2.42