### PR TITLE
fix(bulk): pass dataStore to mandatory fields validator

### DIFF
--- a/src/hooks/template_validation/useValidateFile.ts
+++ b/src/hooks/template_validation/useValidateFile.ts
@@ -31,8 +31,8 @@ const useValidateFile = (program: any, mutateType: "POST" | "UPDATE") => {
     const { sectionType, school } = urlParameters
     const Profile = (sectionType ?? '').substring(0, 1).toUpperCase() + (sectionType ?? '').substring(1, (sectionType ?? '').length) + ' profile'
 
-    const validador = async ({ module, data }: { module: string, data: any[] }) => {
-        const { invalidData, uniqueAttributes, validData } = madatoryFieldsValidator(program, data, module, Profile)
+    const validador = async ({ module, data, dataStore }: { module: string, data: any[], dataStore: any }) => {
+        const { invalidData, uniqueAttributes, validData } = madatoryFieldsValidator(program, data, module, Profile, dataStore)
         setInvalidRecords(invalidData)
 
         if (module !== "enrollment") {

--- a/src/utils/bulk/validateMandatoryFields.ts
+++ b/src/utils/bulk/validateMandatoryFields.ts
@@ -4,7 +4,7 @@ const DATE_FORMAT_VALIDATION_ERROR = "Invalid date format. Expected YYYY-MM-DD"
 const DATE_VALUE_VALIDATION_ERROR = "Invalid date value. Use a real date in YYYY-MM-DD"
 const DATE_VALUE_TYPE = "DATE"
 
-const madatoryFieldsValidator = (program: any, fileRowData: any, module: string, profile: string) => {
+const madatoryFieldsValidator = (program: any, fileRowData: any, module: string, profile: string, dataStore: any) => {
     const validData: any[] = []
     const invalidData: any[] = []
     const students = fileRowData
@@ -16,7 +16,7 @@ const madatoryFieldsValidator = (program: any, fileRowData: any, module: string,
 
     students.forEach((student: any) => {
         const mandatoryAttributeErrors = validateMandatoryAttributtes(student, madatoryFieldsAttributes, profile)
-        const mandatoryDataElementErrors = validateMandatoryDataElements(student, program, profile)
+        const mandatoryDataElementErrors = validateMandatoryDataElements(student, program, profile, dataStore, module)
         const invalidDateFormatErrors = validateDateFields(student, program, profile)
 
         if (mandatoryAttributeErrors.length === 0 && mandatoryDataElementErrors.length === 0 && invalidDateFormatErrors.length === 0) {
@@ -61,9 +61,17 @@ const validateMandatoryAttributtes = (student: any, madatoryFieldsAttributes: an
     });
 }
 
-const validateMandatoryDataElements = (student: any, program: any, profile: string): [] => {
+const validateMandatoryDataElements = (student: any, program: any, profile: string, dataStore: any, module: string): [] => {
+    const toValidateProgramStage = {
+        "final-result": [dataStore?.['final-result']?.programStage],
+        "enrollment": [dataStore?.registration?.programStage,
+        dataStore?.['socio-economics']?.programStage],
+        "attendance": [dataStore?.attendance?.programStage],
+        "performance": [dataStore?.performance?.programStages?.map((item: any) => item?.programStage)?.join(",")],
+    }
     //GET ALL PROGRAM STAGES WITH AT LEAST ONE MANDATORY DATA ELEMENT
     const madatoryFieldsProgramStages = program?.programStages.map((programStage: any) => {
+        if (!toValidateProgramStage?.[module]?.includes(programStage.id)) return null;
         const compulsoryElements = programStage.programStageDataElements.filter((el: any) => el.compulsory);
         if (compulsoryElements.length === 0) return null;
         return {


### PR DESCRIPTION
The validator now receives dataStore to filter program stages by module, ensuring only relevant mandatory data elements are validated. This prevents false validation errors when program stages contain mandatory elements for other modules.