### PR TITLE
fix: add orgUnitMode ACCESSIBLE to getTeis call

### DIFF
--- a/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
+++ b/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
@@ -16,7 +16,7 @@ export function useGetEnrollmentData(props: ExportData) {
         const trackedEntityIds = events?.map((x: { trackedEntity: string }) => x.trackedEntity).join(',')
 
         try {
-            return getTeis({ program: selectedSectionDataStore?.program as unknown as string, trackedEntities: trackedEntityIds, orgUnit })
+            return getTeis({ program: selectedSectionDataStore?.program as unknown as string, trackedEntities: trackedEntityIds, orgUnitMode: "ACCESSIBLE"})
                 .then(async (data: any) => {
                     let rows: any = []
                     let counter = 0


### PR DESCRIPTION
ensure API request fetches all tracked entity instances even when ownership isn't in the selected orgUnit